### PR TITLE
Run Gin in Release Mode by default

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -8,6 +8,8 @@ COPY server admin-client settings.json webapp /app/
 
 EXPOSE 8080/tcp
 
+ENV GIN_MODE=release
+
 ENTRYPOINT ["/app/server"]
 VOLUME /app/data
 VOLUME /app/sockets


### PR DESCRIPTION
This PR sets the `GIN_MODE` environment variable to `release` in the Dockerfile.
Containers started will by default run Gin in release mode. This can be overridden by the user on container creation.