### PR TITLE
Enable configuration via env vars

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -62,6 +62,10 @@ func main() {
 	viper.AddConfigPath("$HOME/.config/hadibar/")
 	viper.AddConfigPath("/etc/hadibar")
 	viper.SetConfigName("settings")
+
+	viper.SetEnvPrefix("hadibar")
+	viper.AutomaticEnv()
+
 	viper.ReadInConfig()
 
 	logger.PrepareLoggerFromViper()


### PR DESCRIPTION
Viper will look for a an env var `HADIBAR_ADMINTCPADDR` when "AdminTcpAddr" is looked up.

Empty env vars are considered unset.