### PR TITLE
Fix docker image to be runnable without configuration

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -4,7 +4,8 @@ FROM scratch
 WORKDIR /app
 
 # Now just add the binary
-COPY server admin-client settings.json webapp /app/
+COPY server admin-client settings.json /app/
+COPY webapp/ /app/webapp/
 
 EXPOSE 8080/tcp
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,16 +1,24 @@
-# iron/go is the alpine image with only ca-certificates added
+FROM busybox AS builder
+RUN mkdir /empty-dir
+
 FROM scratch
 
 WORKDIR /app
 
-# Now just add the binary
-COPY server admin-client settings.json /app/
+# Now just add the binaries, settings and web resources
+COPY server admin-client dockerfiles/settings.json /app/
 COPY webapp/ /app/webapp/
+
+# Copy empty directory (as mkdir is not available in scratch)
+COPY --from=builder /empty-dir /sockets
 
 EXPOSE 8080/tcp
 
-ENV GIN_MODE=release
+ENV GIN_MODE=release \
+	HADIBAR_PORT=8080 \
+	HADIBAR_SOCKETPATH=/sockets \
+	HADIBAR_LOGGINGLEVEL=DEBUG
 
 ENTRYPOINT ["/app/server"]
-VOLUME /app/data
-VOLUME /app/sockets
+VOLUME /data
+VOLUME /logs

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -3,6 +3,10 @@ RUN mkdir /empty-dir
 
 FROM scratch
 
+# Set a random and static user id for the hadibar user (and group).
+# Operators may have to configure write access of additional volume mounts for this user id.
+ARG HADIBAR_USER_ID=30159
+
 WORKDIR /app
 
 # Now just add the binaries, settings and web resources
@@ -10,7 +14,11 @@ COPY server admin-client dockerfiles/settings.json /app/
 COPY webapp/ /app/webapp/
 
 # Copy empty directory (as mkdir is not available in scratch)
-COPY --from=builder /empty-dir /sockets
+COPY --from=builder --chown=${HADIBAR_USER_ID}:${HADIBAR_USER_ID} /empty-dir /sockets
+COPY --from=builder --chown=${HADIBAR_USER_ID}:${HADIBAR_USER_ID} /empty-dir /data
+COPY --from=builder --chown=${HADIBAR_USER_ID}:${HADIBAR_USER_ID} /empty-dir /logs
+
+USER ${HADIBAR_USER_ID}:${HADIBAR_USER_ID}
 
 EXPOSE 8080/tcp
 

--- a/dockerfiles/settings.json
+++ b/dockerfiles/settings.json
@@ -1,0 +1,11 @@
+{
+    "DataDir":"/data",
+    "WebAppDir":"webapp/",
+    "WebAppRoute":"/app",
+
+    "LogDir": "/logs",
+    "LogMaxSize": 100,
+    "LogMaxAge": 30,
+    "LogMaxBackups": 12,
+    "LogCompress": false
+}


### PR DESCRIPTION
This PR is comprised of multiple changes making the default container created from the docker image saner.

The docker image can be run like this:
```shell
$ docker run -d -P hadibar
```

This PR changes volumes and permissions set on volume contents. Any existing installation must in all likelihood be amended to continue working.