### PR TITLE
Add current golang version (1.13) to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,5 @@ require (
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
This indicates that the project must be built using a Go 1.13 compatible Go version.