### PR TITLE
Alpine based Dockerfile containing admin-client

### DIFF
--- a/dockerfiles/Dockerfile-admin-client
+++ b/dockerfiles/Dockerfile-admin-client
@@ -1,0 +1,4 @@
+FROM alpine:3
+
+# Add the binary to directory in PATH
+COPY admin-client /usr/local/bin/


### PR DESCRIPTION
Additional tooling is required in order to use the admin-client binary in a meaningful way. For example, a shell script is required to check the return code of operations and perform mitigations in case of error. Dynamic parameters require commands like date and pipelined processing requires jq to interpret responses.

For these reasons, an alpine variant of the docker image containing the admin-client executable is of interest. Alpine is preferable over pure busybox, because further required packages can be installed.

Entrypoint is not specified in the image. That means users have to use `admin-client ...` as the command. Alternatively, an entrypoint script could be included which automatically adds the `admin-client` part if the user's command is recognised as an admin-client sub-command.